### PR TITLE
chore(Restaurants): Migrate #83 - Implement restaurant card

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,12 +1,19 @@
 module.exports = {
   root: true,
   extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended', 'prettier'],
-  plugins: ['@typescript-eslint'],
+  plugins: ['@typescript-eslint', 'import', 'simple-import-sort'],
   parser: '@typescript-eslint/parser',
   rules: {
     quotes: ['error', 'single'],
+    '@typescript-eslint/no-explicit-any': ['error', { ignoreRestArgs: true }],
+    'import/first': 'error',
+    'import/order': 'off',
+    'import/newline-after-import': 'error',
+    'import/no-duplicates': 'error',
     'no-console': 'error',
     'no-debugger': 'error',
-    '@typescript-eslint/no-explicit-any': ['error', { ignoreRestArgs: true }],
+    'simple-import-sort/imports': 'error',
+    'simple-import-sort/exports': 'error',
+    'sort-imports': 'off',
   },
 };

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@types/node": "^14.14.3",
     "@types/react": "^16.9.53",
     "@types/react-dom": "^16.9.8",
+    "date-fns": "^2.16.1",
     "react": "^17.0.0",
     "react-dom": "^17.0.0",
     "react-scripts": "3.4.4",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "dotenv": "^8.2.0",
     "eslint-config-prettier": "^6.15.0",
     "eslint-plugin-prettier": "^3.1.4",
+    "eslint-plugin-simple-import-sort": "^7.0.0",
     "google-maps-react": "^2.0.6",
     "husky": "^4.3.0",
     "lint-staged": "^10.5.0",

--- a/src/Router.tsx
+++ b/src/Router.tsx
@@ -1,8 +1,9 @@
 import React, { ReactElement } from 'react';
-import { BrowserRouter, Switch, Route } from 'react-router-dom';
+import { BrowserRouter, Route, Switch } from 'react-router-dom';
 
 import NavigationBar from './components/navigation/NavigationBar';
 import { PromotionsListProvider } from './contexts/PromotionsListContext';
+import { RestaurantCardProvider } from './contexts/RestaurantCardContext';
 import Home from './screens/Home';
 import MyPromotions from './screens/MyPromotions';
 
@@ -21,7 +22,9 @@ export default function Router(): ReactElement {
           <Route path="/promotion/upload">{/* <UploadPromotion /> */}</Route>
           <Route path="/">
             <PromotionsListProvider>
-              <Home />
+              <RestaurantCardProvider>
+                <Home />
+              </RestaurantCardProvider>
             </PromotionsListProvider>
           </Route>
         </Switch>

--- a/src/components/DropdownMenu.tsx
+++ b/src/components/DropdownMenu.tsx
@@ -1,10 +1,10 @@
-import React, { CSSProperties, ReactElement, useCallback } from 'react';
 import { Col, Row, Typography } from 'antd';
+import React, { CSSProperties, ReactElement, useCallback } from 'react';
 
-import Dropdown from './dropdown/Dropdown';
+import { DropdownProvider, useDropdown } from '../contexts/DropdownContext';
 import { DispatchAction, usePromotionsList } from '../contexts/PromotionsListContext';
 import { Dropdown as DropdownType } from '../types/dropdown';
-import { DropdownProvider, useDropdown } from '../contexts/DropdownContext';
+import Dropdown from './dropdown/Dropdown';
 
 const { Text } = Typography;
 

--- a/src/components/MapContainer.tsx
+++ b/src/components/MapContainer.tsx
@@ -1,5 +1,5 @@
+import { GoogleApiWrapper, Map, Marker } from 'google-maps-react';
 import React, { ReactElement, useEffect, useState } from 'react';
-import { Map, GoogleApiWrapper, Marker } from 'google-maps-react';
 
 const locations: google.maps.LatLngLiteral[] = [
   { lat: 49.246213, lng: -123.1691 },

--- a/src/components/PromotionList.tsx
+++ b/src/components/PromotionList.tsx
@@ -20,7 +20,7 @@ export default function PromotionList({
 }): ReactElement {
   const [promotions, setPromotions] = useState<Promotion[]>([]);
 
-  const { state, dispatch } = usePromotionsList();
+  const { state: promotionListState, dispatch } = usePromotionsList();
 
   const containerStyles = {
     marginLeft: `calc(100vw - ${dimensions.width})`,
@@ -29,13 +29,16 @@ export default function PromotionList({
   };
 
   /**
-   * Fetches promotions satisfying the current query and sorts them
+   * This hook is run everytime the promotionsListState changes. This function sorts and filters the promotions
+   * according to the `filter` and `sort` keys so that this component is displaying the appropriate list.
    */
   useEffect(() => {
     dispatch({ type: DispatchAction.DATA_LOADING });
-    filterPromotions(state.filter)
-      .then((filteredPromotions) => sortPromotions(filteredPromotions, state.sort))
-      .then((sortedPromotions) => {
+    filterPromotions(promotionListState.filter)
+      .then((filteredPromotions: Promotion[]) =>
+        sortPromotions(filteredPromotions, promotionListState.sort)
+      )
+      .then((sortedPromotions: Promotion[]) => {
         dispatch({ type: DispatchAction.DATA_SUCCESS });
         setPromotions(sortedPromotions);
       })
@@ -43,7 +46,7 @@ export default function PromotionList({
         dispatch({ type: DispatchAction.DATA_FAILURE });
         setPromotions([]);
       });
-  }, [state.filter, state.sort, dispatch]);
+  }, [promotionListState.filter, promotionListState.sort, dispatch]);
 
   return (
     <div style={containerStyles}>

--- a/src/components/PromotionList.tsx
+++ b/src/components/PromotionList.tsx
@@ -7,6 +7,7 @@ import { Promotion } from '../types/promotion';
 
 const styles: { [identifier: string]: CSSProperties } = {
   container: {
+    backgroundColor: '#FFEDDC',
     padding: 15,
     paddingBottom: 0,
     overflow: 'auto',
@@ -14,7 +15,7 @@ const styles: { [identifier: string]: CSSProperties } = {
 };
 
 export default function PromotionList({
-  dimensions,
+  dimensions: { width, height },
 }: {
   dimensions: { width: string; height: string };
 }): ReactElement {
@@ -23,8 +24,9 @@ export default function PromotionList({
   const { state: promotionListState, dispatch } = usePromotionsList();
 
   const containerStyles = {
-    marginLeft: `calc(100vw - ${dimensions.width})`,
-    ...dimensions,
+    height,
+    width,
+    marginLeft: `calc(100vw - ${width})`,
     ...styles.container,
   };
 

--- a/src/components/button/UploadPromoButton.tsx
+++ b/src/components/button/UploadPromoButton.tsx
@@ -1,7 +1,7 @@
+import { PlusOutlined } from '@ant-design/icons';
+import { Button } from 'antd';
 import React, { CSSProperties, ReactElement } from 'react';
 import { useHistory } from 'react-router-dom';
-import { Button } from 'antd';
-import { PlusOutlined } from '@ant-design/icons';
 
 const styles: { [identifier: string]: CSSProperties } = {
   button: {

--- a/src/components/dropdown/Dropdown.tsx
+++ b/src/components/dropdown/Dropdown.tsx
@@ -25,4 +25,4 @@ export default function Dropdown(dropdown: DDType): ReactElement {
   }
 }
 
-export { DropdownSelect, DropdownMultiSelect };
+export { DropdownMultiSelect, DropdownSelect };

--- a/src/components/dropdown/DropdownMultiSelect.tsx
+++ b/src/components/dropdown/DropdownMultiSelect.tsx
@@ -1,10 +1,11 @@
-import React, { CSSProperties, ReactElement, useCallback, useEffect, useState } from 'react';
-import { Checkbox, Col, Dropdown as DD, Row } from 'antd';
+import './Dropdown.css';
+
 import { DownOutlined } from '@ant-design/icons';
+import { Checkbox, Col, Dropdown as DD, Row } from 'antd';
+import React, { CSSProperties, ReactElement, useCallback, useEffect, useState } from 'react';
 
 import { DispatchAction, useDropdown } from '../../contexts/DropdownContext';
 import { Dropdown as DropdownType, DropdownAction } from '../../types/dropdown';
-import './Dropdown.css';
 
 const styles: { [identifier: string]: CSSProperties } = {
   active: {

--- a/src/components/dropdown/DropdownSelect.tsx
+++ b/src/components/dropdown/DropdownSelect.tsx
@@ -1,11 +1,11 @@
-import React, { CSSProperties, ReactElement, useCallback, useEffect, useState } from 'react';
-import { Col, Dropdown, Radio } from 'antd';
+import './Dropdown.css';
+
 import { DownOutlined } from '@ant-design/icons';
+import { Col, Dropdown, Radio } from 'antd';
+import React, { CSSProperties, ReactElement, useCallback, useEffect, useState } from 'react';
 
 import { DispatchAction, useDropdown } from '../../contexts/DropdownContext';
-import { Dropdown as DropdownType } from '../../types/dropdown';
-import { DropdownAction } from '../../types/dropdown';
-import './Dropdown.css';
+import { Dropdown as DropdownType, DropdownAction } from '../../types/dropdown';
 
 const { Group } = Radio;
 

--- a/src/components/navigation/NavigationBar.tsx
+++ b/src/components/navigation/NavigationBar.tsx
@@ -1,6 +1,6 @@
+import { Menu } from 'antd';
 import React, { CSSProperties, ReactElement, useState } from 'react';
 import { Link } from 'react-router-dom';
-import { Menu } from 'antd';
 
 import SearchBar from './SearchBar';
 

--- a/src/components/navigation/SearchBar.tsx
+++ b/src/components/navigation/SearchBar.tsx
@@ -1,5 +1,5 @@
-import React, { CSSProperties, ReactElement } from 'react';
 import { Input } from 'antd';
+import React, { CSSProperties, ReactElement } from 'react';
 
 const { Search } = Input;
 

--- a/src/components/promotion/PromotionCard.tsx
+++ b/src/components/promotion/PromotionCard.tsx
@@ -11,11 +11,14 @@ import PromotionImage from '../promotion/PromotionImage';
 const styles: { [identifier: string]: CSSProperties } = {
   body: {
     display: 'inline-flex',
+    padding: 10,
     textAlign: 'left',
     width: '100%',
-    padding: 10,
   },
   card: {
+    borderRadius: 15,
+    borderWidth: 0,
+    boxShadow: '2px 2px 4px 0px #40333333',
     cursor: 'pointer',
     display: 'inline-block',
     marginBottom: 15,

--- a/src/components/promotion/PromotionCard.tsx
+++ b/src/components/promotion/PromotionCard.tsx
@@ -1,17 +1,22 @@
-import React, { CSSProperties, ReactElement } from 'react';
 import { Card } from 'antd';
+import React, { CSSProperties, ReactElement, useCallback } from 'react';
 
+import { DispatchAction, useRestaurantCard } from '../../contexts/RestaurantCardContext';
+import { getRestaurant } from '../../services/PromotionService';
+import { Promotion } from '../../types/promotion';
+import { Restaurant } from '../../types/restaurant';
 import PromotionDetails from '../promotion/PromotionDetails';
 import PromotionImage from '../promotion/PromotionImage';
-import { Promotion } from '../../types/promotion';
 
 const styles: { [identifier: string]: CSSProperties } = {
   body: {
     display: 'inline-flex',
     textAlign: 'left',
     width: '100%',
+    padding: 10,
   },
   card: {
+    cursor: 'pointer',
     display: 'inline-block',
     marginBottom: 15,
     width: '100%',
@@ -19,8 +24,35 @@ const styles: { [identifier: string]: CSSProperties } = {
 };
 
 export default function PromotionCard(promotion: Promotion): ReactElement {
+  const { state, dispatch } = useRestaurantCard();
+
+  /**
+   * Gets the restaurant associated with the clicked promotion and toggles visible state of restaurant details card.
+   *
+   * Shows the restaurant card if:
+   * - card was previously closed
+   * - clicked restaurant differs from restaurant currently being shown
+   *
+   * Hides the restaurant card if:
+   * - card is currently open and we click the associated promotion
+   * - matching restaurant results in an error
+   */
+  const onClickHandler = useCallback(async () => {
+    return getRestaurant(promotion)
+      .then((restaurant: Restaurant) => {
+        const isOpeningRestaurantCard = !state.showCard;
+        const isNewRestaurant = state.showCard && state.restaurant.id !== restaurant.id;
+        if (isNewRestaurant || isOpeningRestaurantCard) {
+          dispatch({ type: DispatchAction.SHOW_CARD, payload: { restaurant } });
+        } else {
+          dispatch({ type: DispatchAction.HIDE_CARD });
+        }
+      })
+      .catch(() => dispatch({ type: DispatchAction.HIDE_CARD }));
+  }, [state, dispatch, promotion]);
+
   return (
-    <Card style={styles.card} bodyStyle={styles.body}>
+    <Card style={styles.card} bodyStyle={styles.body} onClick={onClickHandler}>
       <PromotionImage {...promotion.image} />
       <PromotionDetails {...promotion} />
     </Card>

--- a/src/components/promotion/PromotionDetails.css
+++ b/src/components/promotion/PromotionDetails.css
@@ -1,0 +1,10 @@
+/* Promotion text description */
+.promotion-description {
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  display: -webkit-box;
+  margin-bottom: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  word-break: break-all;
+}

--- a/src/components/promotion/PromotionDetails.tsx
+++ b/src/components/promotion/PromotionDetails.tsx
@@ -4,7 +4,7 @@ import { ClockCircleOutlined, HeartOutlined } from '@ant-design/icons';
 import { Col, Row, Typography } from 'antd';
 import React, { CSSProperties, ReactElement } from 'react';
 
-import { Promotion } from '../../types/promotion';
+import { Promotion, Schedule } from '../../types/promotion';
 
 const { Title, Text } = Typography;
 
@@ -53,6 +53,7 @@ export default function PromotionDetails({
   description,
   expirationDate,
   restaurantName,
+  schedules,
 }: Promotion): ReactElement {
   /**
    * Returns display text for age of promotion.
@@ -104,6 +105,30 @@ export default function PromotionDetails({
     }
   };
 
+  const displaySchedules = (schedules: Schedule[]) => {
+    const formatTime = (startTime: string): string => {
+      const [hour, minute] = startTime.split(':');
+
+      const hourNum = parseInt(hour);
+      const minuteNum = parseInt(minute);
+
+      let formattedTime = `${hourNum === 12 ? hourNum : hourNum % 12}`;
+      if (minuteNum !== 0) {
+        formattedTime += `:${minuteNum}`;
+      }
+      formattedTime += hourNum < 12 ? ' AM' : ' PM';
+      return formattedTime;
+    };
+
+    return schedules.map(({ dayOfWeek, startTime, endTime }) => (
+      <Row>
+        <Text style={styles.schedule}>
+          {dayOfWeek}: {formatTime(startTime) + ' - ' + formatTime(endTime)}
+        </Text>
+      </Row>
+    ));
+  };
+
   const Info = () => (
     <>
       <Row style={styles.header}>
@@ -126,16 +151,9 @@ export default function PromotionDetails({
   const Schedule = () => (
     <Row style={styles.scheduleContainer}>
       <Col span={2}>
-        <ClockCircleOutlined style={{ fontSize: '1em', ...styles.schedule }} />
+        <ClockCircleOutlined style={styles.schedule} />
       </Col>
-      <Col span={22}>
-        <Row>
-          <Text style={styles.schedule}>Tuesday: 10 AM - Late</Text>
-        </Row>
-        <Row>
-          <Text style={styles.schedule}>Wednesday: 7 PM - Late</Text>
-        </Row>
-      </Col>
+      <Col span={22}>{displaySchedules(schedules)}</Col>
     </Row>
   );
 

--- a/src/components/promotion/PromotionDetails.tsx
+++ b/src/components/promotion/PromotionDetails.tsx
@@ -1,21 +1,49 @@
-import { HeartOutlined } from '@ant-design/icons';
+import './PromotionDetails.css';
+
+import { ClockCircleOutlined, HeartOutlined } from '@ant-design/icons';
+import { Col, Row, Typography } from 'antd';
 import React, { CSSProperties, ReactElement } from 'react';
 
 import { Promotion } from '../../types/promotion';
 
+const { Title, Text } = Typography;
+
 const styles: { [identifier: string]: CSSProperties } = {
-  descriptionContainer: {
-    padding: 10,
+  detailsContainer: {
+    paddingLeft: 10,
     textAlign: 'left',
     width: '100%',
   },
+  footer: {
+    color: '#8B8888',
+    fontSize: '0.8em',
+  },
   header: {
-    display: 'flex',
-    justifyContent: 'space-between',
+    fontFamily: 'ABeeZee',
+    fontSize: '1em',
+    lineHeight: '1em',
+    paddingBottom: 5,
   },
   heart: {
-    marginTop: 7,
-    textAlign: 'right',
+    fontSize: '1.5em',
+  },
+  promotionName: {
+    fontSize: '1.5em',
+    fontWeight: 'normal',
+    marginBottom: 0,
+  },
+  restaurantName: {
+    fontSize: '0.9em',
+    lineHeight: '0.9em',
+    textDecoration: 'underline',
+  },
+  schedule: {
+    color: '#8B8888',
+    fontSize: '0.9em',
+  },
+  scheduleContainer: {
+    paddingTop: 10,
+    paddingBottom: 10,
   },
 };
 
@@ -25,18 +53,60 @@ export default function PromotionDetails({
   expirationDate,
   restaurantName = 'Restaurant',
 }: Promotion): ReactElement {
+  const Info = () => (
+    <>
+      <Row style={styles.header}>
+        <Col span={22}>
+          <Title style={styles.promotionName}>{name}</Title>
+        </Col>
+        <Col span={2}>
+          <HeartOutlined style={styles.heart} />
+        </Col>
+      </Row>
+      <Row>
+        <Title style={styles.restaurantName}>{restaurantName}</Title>
+      </Row>
+      <Row>
+        <Text className="promotion-description">{description}</Text>
+      </Row>
+    </>
+  );
+
+  const Schedule = () => (
+    <Row style={styles.scheduleContainer}>
+      <Col span={2}>
+        <ClockCircleOutlined style={{ fontSize: '1em', ...styles.schedule }} />
+      </Col>
+      <Col span={22}>
+        <Row>
+          <Text style={styles.schedule}>Tuesday: 10 AM - Late</Text>
+        </Row>
+        <Row>
+          <Text style={styles.schedule}>Wednesday: 7 PM - Late</Text>
+        </Row>
+      </Col>
+    </Row>
+  );
+
+  const Footer = () => (
+    <Row justify="space-between">
+      <Col>
+        <Text style={styles.footer}>Expires</Text>
+        <Text strong style={styles.footer}>
+          {` ${new Date(expirationDate).toDateString()}`}
+        </Text>
+      </Col>
+      <Col>
+        <Text style={styles.footer}>8 days ago</Text>
+      </Col>
+    </Row>
+  );
+
   return (
-    <div style={styles.descriptionContainer}>
-      <div style={styles.header}>
-        <h2>{name}</h2>
-        <HeartOutlined style={styles.heart} />
-      </div>
-      <h3>{restaurantName}</h3>
-      <p>{description}</p>
-      <p>
-        Expires on
-        <strong>{` ${new Date(expirationDate).toDateString()}`}</strong>
-      </p>
-    </div>
+    <Col style={styles.detailsContainer}>
+      <Info />
+      <Schedule />
+      <Footer />
+    </Col>
   );
 }

--- a/src/components/promotion/PromotionDetails.tsx
+++ b/src/components/promotion/PromotionDetails.tsx
@@ -49,10 +49,61 @@ const styles: { [identifier: string]: CSSProperties } = {
 
 export default function PromotionDetails({
   name,
+  dateAdded,
   description,
   expirationDate,
-  restaurantName = 'Restaurant',
+  restaurantName,
 }: Promotion): ReactElement {
+  /**
+   * Returns display text for age of promotion.
+   *
+   * - If dateAdded < 1 day, displays "X hours ago"
+   * - If 1 day <= dateAdded < 1 week, displays "X days ago"
+   * - If 1 week <= dateAdded < 1 month, displays "X weeks ago"
+   * - If 1 month <= dateAdded < 1 year, displays "X months ago"
+   * - If 1 year <= dateAdded, displays "X years ago"
+   */
+  const promotionAge = (dateAdded: string) => {
+    const oneDayInMs = 24 * 60 * 60 * 1000;
+    const msElapsed = new Date().getTime() - new Date(dateAdded).getTime();
+    const daysAgo = msElapsed / oneDayInMs;
+
+    if (daysAgo < 1) {
+      const oneHourInMs = oneDayInMs / 24;
+      const hoursAgo = msElapsed / oneHourInMs;
+      if (hoursAgo === 1) {
+        return '1 hour ago';
+      }
+      return `${hoursAgo.toFixed(0)} hours ago`;
+    } else if (daysAgo < 7) {
+      if (daysAgo === 1) {
+        return '1 day ago';
+      }
+      return `${oneDayInMs.toFixed(0)} days ago`;
+    } else if (daysAgo < 30) {
+      const oneWeekInMs = oneDayInMs * 7;
+      const weeksAgo = msElapsed / oneWeekInMs;
+      if (weeksAgo === 1) {
+        return '1 week ago';
+      }
+      return `${weeksAgo.toFixed(0)} weeks ago`;
+    } else if (daysAgo < 365) {
+      const oneMonthInMs = oneDayInMs * 30;
+      const monthsAgo = msElapsed / oneMonthInMs;
+      if (monthsAgo === 1) {
+        return '1 month ago';
+      }
+      return `${monthsAgo.toFixed(0)} months ago`;
+    } else if (daysAgo >= 365) {
+      const oneYearInMs = oneDayInMs * 365;
+      const yearsAgo = msElapsed / oneYearInMs;
+      if (yearsAgo === 1) {
+        return '1 year ago';
+      }
+      return `${yearsAgo.toFixed(0)} years ago`;
+    }
+  };
+
   const Info = () => (
     <>
       <Row style={styles.header}>
@@ -97,7 +148,7 @@ export default function PromotionDetails({
         </Text>
       </Col>
       <Col>
-        <Text style={styles.footer}>8 days ago</Text>
+        <Text style={styles.footer}>{promotionAge(dateAdded)}</Text>
       </Col>
     </Row>
   );

--- a/src/components/promotion/PromotionDetails.tsx
+++ b/src/components/promotion/PromotionDetails.tsx
@@ -1,5 +1,5 @@
-import React, { CSSProperties, ReactElement } from 'react';
 import { HeartOutlined } from '@ant-design/icons';
+import React, { CSSProperties, ReactElement } from 'react';
 
 import { Promotion } from '../../types/promotion';
 

--- a/src/components/promotion/PromotionDetails.tsx
+++ b/src/components/promotion/PromotionDetails.tsx
@@ -2,6 +2,7 @@ import './PromotionDetails.css';
 
 import { ClockCircleOutlined, HeartOutlined } from '@ant-design/icons';
 import { Col, Row, Typography } from 'antd';
+import { formatDistanceToNow } from 'date-fns';
 import React, { CSSProperties, ReactElement } from 'react';
 
 import { Promotion, Schedule } from '../../types/promotion';
@@ -57,52 +58,9 @@ export default function PromotionDetails({
 }: Promotion): ReactElement {
   /**
    * Returns display text for age of promotion.
-   *
-   * - If dateAdded < 1 day, displays "X hours ago"
-   * - If 1 day <= dateAdded < 1 week, displays "X days ago"
-   * - If 1 week <= dateAdded < 1 month, displays "X weeks ago"
-   * - If 1 month <= dateAdded < 1 year, displays "X months ago"
-   * - If 1 year <= dateAdded, displays "X years ago"
    */
   const promotionAge = (dateAdded: string) => {
-    const oneDayInMs = 24 * 60 * 60 * 1000;
-    const msElapsed = new Date().getTime() - new Date(dateAdded).getTime();
-    const daysAgo = msElapsed / oneDayInMs;
-
-    if (daysAgo < 1) {
-      const oneHourInMs = oneDayInMs / 24;
-      const hoursAgo = msElapsed / oneHourInMs;
-      if (hoursAgo === 1) {
-        return '1 hour ago';
-      }
-      return `${hoursAgo.toFixed(0)} hours ago`;
-    } else if (daysAgo < 7) {
-      if (daysAgo === 1) {
-        return '1 day ago';
-      }
-      return `${oneDayInMs.toFixed(0)} days ago`;
-    } else if (daysAgo < 30) {
-      const oneWeekInMs = oneDayInMs * 7;
-      const weeksAgo = msElapsed / oneWeekInMs;
-      if (weeksAgo === 1) {
-        return '1 week ago';
-      }
-      return `${weeksAgo.toFixed(0)} weeks ago`;
-    } else if (daysAgo < 365) {
-      const oneMonthInMs = oneDayInMs * 30;
-      const monthsAgo = msElapsed / oneMonthInMs;
-      if (monthsAgo === 1) {
-        return '1 month ago';
-      }
-      return `${monthsAgo.toFixed(0)} months ago`;
-    } else if (daysAgo >= 365) {
-      const oneYearInMs = oneDayInMs * 365;
-      const yearsAgo = msElapsed / oneYearInMs;
-      if (yearsAgo === 1) {
-        return '1 year ago';
-      }
-      return `${yearsAgo.toFixed(0)} years ago`;
-    }
+    return formatDistanceToNow(new Date(dateAdded), { addSuffix: true });
   };
 
   const displaySchedules = (schedules: Schedule[]) => {

--- a/src/components/promotion/PromotionImage.tsx
+++ b/src/components/promotion/PromotionImage.tsx
@@ -13,7 +13,7 @@ const styles: { [identifier: string]: CSSProperties } = {
 };
 
 export default function PromotionImage({
-  // TODO: remove default image
+  // TODO: see https://github.com/ubclaunchpad/PromoPal-backend/issues/101
   src = 'https://d1ralsognjng37.cloudfront.net/92a7b4fb-892c-47bb-b5bb-884c89c254a2.jpeg',
 }: PromotionImageProps): ReactElement {
   return (

--- a/src/components/promotion/PromotionImage.tsx
+++ b/src/components/promotion/PromotionImage.tsx
@@ -1,8 +1,22 @@
 import { Skeleton } from 'antd';
-import React, { ReactElement } from 'react';
+import React, { CSSProperties, ReactElement } from 'react';
 
 import { PromotionImage as PromotionImageProps } from '../../types/promotion';
 
-export default function PromotionImage({ src }: PromotionImageProps): ReactElement {
-  return <div>{src?.length ? <img src={src} alt="" /> : <Skeleton.Image />}</div>;
+const styles: { [identifier: string]: CSSProperties } = {
+  image: {
+    borderRadius: 15,
+    minHeight: '100%',
+    objectFit: 'cover',
+    width: 100,
+  },
+};
+
+export default function PromotionImage({
+  // TODO: remove default image
+  src = 'https://d1ralsognjng37.cloudfront.net/92a7b4fb-892c-47bb-b5bb-884c89c254a2.jpeg',
+}: PromotionImageProps): ReactElement {
+  return (
+    <div>{src?.length ? <img style={styles.image} src={src} alt="" /> : <Skeleton.Image />}</div>
+  );
 }

--- a/src/components/promotion/PromotionImage.tsx
+++ b/src/components/promotion/PromotionImage.tsx
@@ -1,5 +1,5 @@
-import React, { ReactElement } from 'react';
 import { Skeleton } from 'antd';
+import React, { ReactElement } from 'react';
 
 import { PromotionImage as PromotionImageProps } from '../../types/promotion';
 

--- a/src/components/restaurant/RestaurantCard.tsx
+++ b/src/components/restaurant/RestaurantCard.tsx
@@ -1,0 +1,40 @@
+import { Col } from 'antd';
+import React, { CSSProperties, ReactElement } from 'react';
+
+import { Restaurant } from '../../types/restaurant';
+import Body from './card/Body';
+import Header from './card/Header';
+
+const styles: { [identifier: string]: CSSProperties } = {
+  card: {
+    backgroundColor: 'white',
+    borderRadius: 15,
+    boxShadow: '0 4px 4px 0 #40333333',
+    padding: 0,
+    position: 'absolute',
+    width: 350,
+    zIndex: 10,
+  },
+  container: {
+    height: '100%',
+    marginTop: 60,
+    position: 'absolute',
+    width: '100%',
+  },
+};
+
+export default function RestaurantCard(restaurant: Restaurant): ReactElement {
+  return (
+    <div style={styles.container}>
+      <Col
+        style={{
+          ...styles.card,
+          left: `calc(70% - 15px - ${styles.card.width}px)`,
+        }}
+      >
+        <Header {...restaurant} />
+        <Body {...restaurant} />
+      </Col>
+    </div>
+  );
+}

--- a/src/components/restaurant/RestaurantCard.tsx
+++ b/src/components/restaurant/RestaurantCard.tsx
@@ -24,12 +24,14 @@ const styles: { [identifier: string]: CSSProperties } = {
 };
 
 export default function RestaurantCard(restaurant: Restaurant): ReactElement {
+  const containerPadding = '15px';
+
   return (
     <div style={styles.container}>
       <Col
         style={{
           ...styles.card,
-          left: `calc(70% - 15px - ${styles.card.width}px)`,
+          left: `calc(65% - ${containerPadding} - ${styles.card.width}px)`,
         }}
       >
         <Header {...restaurant} />

--- a/src/components/restaurant/card/Body.css
+++ b/src/components/restaurant/card/Body.css
@@ -1,0 +1,43 @@
+/* Tab bar */
+.ant-tabs-nav-wrap {
+  background-color: #ffeddc;
+  margin-top: 10px;
+  margin-bottom: -10px;
+}
+
+/* Tab bar button spacing */
+.ant-tabs .ant-tabs-nav-wrap .ant-tabs-nav-list .ant-tabs-tab {
+  padding-left: 20px;
+  padding-right: 20px;
+  margin-right: 0px;
+}
+
+/* Active tab bar */
+.ant-tabs .ant-tabs-nav-wrap .ant-tabs-nav-list .ant-tabs-tab.ant-tabs-tab-active {
+  background-color: #fac15e;
+}
+
+/* Active tab bar button text */
+.ant-tabs
+  .ant-tabs-nav-wrap
+  .ant-tabs-nav-list
+  .ant-tabs-tab.ant-tabs-tab-active
+  .ant-tabs-tab-btn {
+  font-weight: bold;
+}
+
+/* Hover: tab bar div */
+.ant-tabs .ant-tabs-nav-wrap .ant-tabs-nav-list .ant-tabs-tab:hover {
+  color: #333;
+}
+
+/* Tab bar button text */
+.ant-tabs .ant-tabs-nav-wrap .ant-tabs-nav-list .ant-tabs-tab .ant-tabs-tab-btn {
+  color: #333;
+}
+
+/* Remove underline on active tab */
+.ant-tabs .ant-tabs-nav-list .ant-tabs-ink-bar.ant-tabs-ink-bar-animated {
+  height: 0;
+  width: 0;
+}

--- a/src/components/restaurant/card/Body.tsx
+++ b/src/components/restaurant/card/Body.tsx
@@ -1,0 +1,78 @@
+import './Body.css';
+
+import { Col, Row, Tabs, Typography } from 'antd';
+import React, { CSSProperties, ReactElement } from 'react';
+
+import { Restaurant } from '../../../types/restaurant';
+
+const { TabPane } = Tabs;
+const { Text } = Typography;
+
+const styles: { [identifier: string]: CSSProperties } = {
+  section: {
+    paddingBottom: 10,
+  },
+  sectionDetails: {
+    whiteSpace: 'pre-line',
+  },
+  tabContent: {
+    flex: 'inherit',
+    margin: '10px 20px',
+    wordBreak: 'break-word',
+  },
+  tabs: {
+    width: '100%',
+  },
+};
+
+function Section({ title, details }: { title: string; details: string }): ReactElement {
+  return (
+    <Col span={24} style={styles.section}>
+      <Row>
+        <Text strong>{title}:</Text>
+      </Row>
+      <Row style={styles.sectionDetails}>{details}</Row>
+    </Col>
+  );
+}
+
+export default function Body({ address, hours, phoneNumber }: Restaurant): ReactElement {
+  function formatHours(hours: Restaurant['hours']): string {
+    return `Sun: ${hours.sunday}
+      Mon: ${hours.monday}
+      Tue: ${hours.tuesday}
+      Wed: ${hours.wednesday}
+      Thu: ${hours.thursday}
+      Fri: ${hours.friday}
+      Sat: ${hours.saturday}
+    `;
+  }
+
+  function formatPhoneNumber(phoneNumber: string): string {
+    const segments = phoneNumber.split('-');
+    if (segments.length > 1) {
+      const areaCode = segments[0];
+      const kebab = segments.slice(1).join('-');
+      return `(${areaCode}) ${kebab}`;
+    }
+    return phoneNumber;
+  }
+
+  return (
+    <Row>
+      <Tabs style={styles.tabs} defaultActiveKey="1" size="small">
+        <TabPane tab="Info" key="1" style={styles.tabContent}>
+          <Section title="Address" details={address} />
+          <Section title="Hours" details={formatHours(hours)} />
+          <Section title="Phone" details={formatPhoneNumber(phoneNumber)} />
+        </TabPane>
+        <TabPane tab="Promotions" key="2" style={styles.tabContent}>
+          Promotions
+        </TabPane>
+        <TabPane tab="Photos" key="3" style={styles.tabContent}>
+          Photos
+        </TabPane>
+      </Tabs>
+    </Row>
+  );
+}

--- a/src/components/restaurant/card/Header.css
+++ b/src/components/restaurant/card/Header.css
@@ -1,0 +1,4 @@
+/* Hover: link colour */
+button.ant-btn:hover {
+  color: #333;
+}

--- a/src/components/restaurant/card/Header.tsx
+++ b/src/components/restaurant/card/Header.tsx
@@ -1,0 +1,120 @@
+import './Header.css';
+
+import { CloseCircleOutlined } from '@ant-design/icons';
+import { Button, Col, Rate, Row, Typography } from 'antd';
+import React, { CSSProperties, ReactElement } from 'react';
+
+import { DispatchAction, useRestaurantCard } from '../../../contexts/RestaurantCardContext';
+import { Restaurant } from '../../../types/restaurant';
+
+const { Text, Title } = Typography;
+
+const styles: { [identifier: string]: CSSProperties } = {
+  buttons: {
+    paddingBottom: 10,
+    paddingTop: 10,
+  },
+  button: {
+    border: '1px solid #FFC529',
+    borderRadius: 20,
+    boxShadow: '0 4px 4px 0 #40333333',
+    fontSize: '0.9em',
+    fontWeight: 'bold',
+    paddingLeft: 8,
+    paddingRight: 8,
+  },
+  closeModal: {
+    fontSize: '1.5em',
+    color: '#6E798C',
+    float: 'right',
+  },
+  container: {
+    margin: 20,
+    marginBottom: 0,
+  },
+  detailsText: {
+    fontWeight: 'bold',
+    marginRight: 20,
+    marginTop: 10,
+    fontSize: '0.9em',
+    color: '#6E798C',
+  },
+  rating: {
+    fontSize: '1em',
+    padding: 0,
+  },
+  restaurantName: {
+    fontFamily: 'ABeeZee',
+    margin: 0,
+  },
+};
+
+export default function Header({
+  cuisineType,
+  distance,
+  name,
+  price,
+  rating,
+  reviews,
+  website,
+}: Restaurant): ReactElement {
+  const { dispatch } = useRestaurantCard();
+
+  const HeaderTitle = () => (
+    <Row>
+      <Col span={22}>
+        <Title level={3} style={styles.restaurantName}>
+          {name}
+        </Title>
+      </Col>
+      <Col span={2}>
+        <CloseCircleOutlined
+          onClick={() => dispatch({ type: DispatchAction.HIDE_CARD })}
+          style={styles.closeModal}
+        />
+      </Col>
+    </Row>
+  );
+
+  const Buttons = () => (
+    <Row align="middle" justify="space-between" style={styles.buttons}>
+      <Button style={styles.button}>
+        <a style={styles.link} href={website}>
+          Website
+        </a>
+      </Button>
+      <Button style={styles.button}>
+        <a style={styles.link} href={reviews}>
+          Reviews
+        </a>
+      </Button>
+      <Button style={styles.button}>
+        {/* TODO: update link */}
+        <a style={styles.link} href="/">
+          Directions
+        </a>
+      </Button>
+      <Button style={styles.button}>
+        {/* TODO: update link */}
+        <a style={styles.link} href="/">
+          Call
+        </a>
+      </Button>
+    </Row>
+  );
+
+  return (
+    <Col style={styles.container}>
+      <HeaderTitle />
+      <Row>
+        <Rate allowHalf disabled defaultValue={rating} style={styles.rating} />
+      </Row>
+      <Row style={styles.details}>
+        <Text style={styles.detailsText}>{cuisineType}</Text>
+        <Text style={styles.detailsText}>{price}</Text>
+        <Text style={styles.detailsText}>{distance}m</Text>
+      </Row>
+      <Buttons />
+    </Col>
+  );
+}

--- a/src/contexts/DropdownContext/index.tsx
+++ b/src/contexts/DropdownContext/index.tsx
@@ -5,6 +5,9 @@ import { Context, DispatchAction, DispatchParams, State } from './types';
 
 const initialState: State = { resetCallbacks: [] };
 
+/**
+ * Holds the most up-to-date context object.
+ */
 const DropdownContext = createContext<Context>({
   state: initialState,
   dispatch: () => null,
@@ -30,6 +33,7 @@ export function DropdownProvider({
 
 /**
  * Use this function to access the context object.
+ * Destructure the return value to access `state` and `dispatch`.
  */
 export function useDropdown(): Context {
   const context = useContext(DropdownContext);

--- a/src/contexts/PromotionsListContext/index.tsx
+++ b/src/contexts/PromotionsListContext/index.tsx
@@ -1,9 +1,8 @@
-import React, { createContext, ReactElement, useContext, useReducer, useEffect } from 'react';
+import React, { createContext, ReactElement, useContext, useEffect, useReducer } from 'react';
 
 import { promotionsListReducer } from '../../reducers/PromotionsListReducer';
 import { getPromotions } from '../../services/PromotionService';
-import { Sort, FilterOptions, Promotion } from '../../types/promotion';
-
+import { FilterOptions, Promotion, Sort } from '../../types/promotion';
 import { Context, DispatchAction, DispatchParams, State } from './types';
 
 export const defaultFilters: FilterOptions = {
@@ -23,6 +22,9 @@ const initialState: State = {
   sort: defaultSort,
 };
 
+/**
+ * Holds the most up-to-date context object.
+ */
 const PromotionsListContext = createContext<Context>({
   state: initialState,
   dispatch: () => null,
@@ -66,6 +68,7 @@ export function PromotionsListProvider({
 
 /**
  * Use this function to access the context object.
+ * Destructure the return value to access `state` and `dispatch`.
  */
 export function usePromotionsList(): Context {
   const context = useContext(PromotionsListContext);

--- a/src/contexts/PromotionsListContext/types.ts
+++ b/src/contexts/PromotionsListContext/types.ts
@@ -1,6 +1,6 @@
 import { Dispatch } from 'react';
 
-import { Sort, FilterOptions, Promotion } from '../../types/promotion';
+import { FilterOptions, Promotion, Sort } from '../../types/promotion';
 
 export enum DispatchAction {
   // Data is being fetched from the API

--- a/src/contexts/RestaurantCardContext/index.tsx
+++ b/src/contexts/RestaurantCardContext/index.tsx
@@ -1,0 +1,71 @@
+import React, { createContext, ReactElement, useContext, useEffect, useReducer } from 'react';
+
+import { restaurantCardReducer } from '../../reducers/RestaurantCardReducer';
+import { Restaurant } from '../../types/restaurant';
+import { usePromotionsList } from '../PromotionsListContext';
+import { Context, DispatchAction, DispatchParams, State } from './types';
+
+export const initialState: State = {
+  showCard: false,
+  restaurant: {} as Restaurant,
+};
+
+/**
+ * Holds the most up-to-date context object.
+ */
+const RestaurantCardContext = createContext<Context>({
+  state: initialState,
+  dispatch: () => null,
+});
+
+/**
+ * @component RestaurantCardProvider
+ * The context provider component for the restaurant card.
+ *
+ * @param children - The child components or elements
+ */
+export function RestaurantCardProvider({
+  children,
+}: {
+  children: ReactElement | ReactElement[];
+}): ReactElement {
+  const [state, dispatch] = useReducer(restaurantCardReducer, initialState);
+
+  const PromotionsContext = usePromotionsList();
+
+  /**
+   * On first load, hide restaurant card.
+   */
+  useEffect(() => {
+    dispatch({ type: DispatchAction.HIDE_CARD });
+  }, []);
+
+  /**
+   * If filter or sort keys for promotions change (i.e., dropdown buttons are used), hide the restaurant card.
+   */
+  useEffect(() => {
+    dispatch({ type: DispatchAction.HIDE_CARD });
+  }, [PromotionsContext.state.filter, PromotionsContext.state.sort]);
+
+  return (
+    <RestaurantCardContext.Provider value={{ state, dispatch }}>
+      {children}
+    </RestaurantCardContext.Provider>
+  );
+}
+
+/**
+ * Use this function to access the context object.
+ * Destructure the return value to access `state` and `dispatch`.
+ */
+export function useRestaurantCard(): Context {
+  const context = useContext(RestaurantCardContext);
+  if (!context) {
+    throw new Error('useRestaurantCard must be used within a RestaurantCardContext');
+  }
+  return context;
+}
+
+/* Re-export types */
+export type { Context, DispatchParams, State };
+export { DispatchAction };

--- a/src/contexts/RestaurantCardContext/types.ts
+++ b/src/contexts/RestaurantCardContext/types.ts
@@ -1,0 +1,46 @@
+import { Dispatch } from 'react';
+
+import { Restaurant } from '../../types/restaurant';
+
+export enum DispatchAction {
+  // Hide restaurant card
+  HIDE_CARD,
+  // Show restaurant card
+  SHOW_CARD,
+}
+
+/**
+ * @type Context
+ * The context to be provided through the component tree.
+ *
+ * @property state - The current state
+ * @property dispatch - The function used to update the state
+ */
+export type Context = {
+  state: State;
+  dispatch: Dispatch<DispatchParams>;
+};
+
+/**
+ * @type DispatchParams
+ * The parameters and their types for the dispatch call (for updating state).
+ *
+ * @property type - The type of action performed
+ * @property payload? - Any data needed to update the state
+ */
+export type DispatchParams = {
+  type: DispatchAction;
+  payload?: unknown;
+};
+
+/**
+ * @type State
+ * The single source of truth for state related to the restaurant card.
+ *
+ * @property showCard - Whether or not the card is currently being shown
+ * @property restaurant - The last selected restaurant
+ */
+export type State = {
+  showCard: boolean;
+  restaurant: Restaurant;
+};

--- a/src/index.css
+++ b/src/index.css
@@ -1,7 +1,9 @@
+@import url('https://fonts.googleapis.com/css2?family=ABeeZee&display=swap');
+@import url('https://fonts.googleapis.com/css2?family=Roboto&display=swap');
+
 body {
   margin: 0;
-  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu',
-    'Cantarell', 'Fira Sans', 'Droid Sans', 'Helvetica Neue', sans-serif;
+  font-family: 'Roboto', sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   overflow: hidden;

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,8 +1,10 @@
-import React from 'react';
-import ReactDOM from 'react-dom';
-import App from './App';
 import './index.css';
 import 'antd/dist/antd.css';
+
+import React from 'react';
+import ReactDOM from 'react-dom';
+
+import App from './App';
 
 ReactDOM.render(
   <React.StrictMode>

--- a/src/reducers/PromotionsListReducer.ts
+++ b/src/reducers/PromotionsListReducer.ts
@@ -5,8 +5,13 @@ import {
   DispatchParams,
   State,
 } from '../contexts/PromotionsListContext';
-import { Promotion, FilterOptions, Sort } from '../types/promotion';
+import { FilterOptions, Promotion, Sort } from '../types/promotion';
 
+/**
+ * @function promotionsListReducer Reducer for managing state of list of promotions.
+ *
+ * Updates state to include the given filter key, sort key, and/or list of promotions.
+ */
 export function promotionsListReducer(state: State, { type, payload }: DispatchParams): State {
   let nextState = state;
 

--- a/src/reducers/RestaurantCardReducer.ts
+++ b/src/reducers/RestaurantCardReducer.ts
@@ -1,0 +1,34 @@
+import { DispatchAction, DispatchParams, State } from '../contexts/RestaurantCardContext';
+import { Restaurant } from '../types/restaurant';
+
+/**
+ * @function restaurantCardReducer Reducer for managing state of restaurant card.
+ *
+ * If card is currently visible, hide the card. Otherwise, card is currently hidden and we set the restaurant
+ * to the given restaurant (if not given, use the current restaurant in state).
+ */
+export function restaurantCardReducer(state: State, { type, payload }: DispatchParams): State {
+  let nextState = state;
+
+  switch (type) {
+    case DispatchAction.SHOW_CARD: {
+      const { restaurant } = payload as { restaurant: Restaurant };
+      nextState = {
+        ...nextState,
+        restaurant: restaurant ?? state.restaurant,
+        showCard: true,
+      };
+      break;
+    }
+    case DispatchAction.HIDE_CARD:
+      nextState = {
+        ...nextState,
+        restaurant: {} as Restaurant,
+        showCard: false,
+      };
+      break;
+    default:
+      break;
+  }
+  return nextState;
+}

--- a/src/screens/Home.tsx
+++ b/src/screens/Home.tsx
@@ -3,13 +3,15 @@ import React, { ReactElement, useEffect, useState } from 'react';
 import DropdownMenu from '../components/DropdownMenu';
 import MapContainer from '../components/MapContainer';
 import PromotionList from '../components/PromotionList';
+import RestaurantCard from '../components/restaurant/RestaurantCard';
 import { DispatchAction, usePromotionsList } from '../contexts/PromotionsListContext';
+import { useRestaurantCard } from '../contexts/RestaurantCardContext';
 import { getEnum } from '../services/EnumService';
 import { Dropdown, DropdownType } from '../types/dropdown';
 import { Sort } from '../types/promotion';
 import Routes from '../utils/routes';
 
-const mapWidth = 60;
+const mapWidth = 70;
 
 export default function Home(): ReactElement {
   const [height, setHeight] = useState<string>('');
@@ -21,6 +23,7 @@ export default function Home(): ReactElement {
   const [promotionTypes, setPromotionTypes] = useState<string[]>([]);
 
   const { dispatch } = usePromotionsList();
+  const { state: restaurantCardState } = useRestaurantCard();
 
   /**
    * On component mount, load dropdown options
@@ -156,7 +159,8 @@ export default function Home(): ReactElement {
   return (
     <>
       <DropdownMenu dropdowns={dropdowns} shadow />
-      <div id="content-container" style={{ display: 'inline-flex', height }}>
+      <div id="content-container" style={{ display: 'inline-flex', height, position: 'relative' }}>
+        {restaurantCardState.showCard && <RestaurantCard {...restaurantCardState.restaurant} />}
         <MapContainer dimensions={{ width: `${mapWidth}vw`, height }} />
         <PromotionList dimensions={{ width: `${100 - mapWidth}vw`, height }} />
       </div>

--- a/src/screens/Home.tsx
+++ b/src/screens/Home.tsx
@@ -11,7 +11,7 @@ import { Dropdown, DropdownType } from '../types/dropdown';
 import { Sort } from '../types/promotion';
 import Routes from '../utils/routes';
 
-const mapWidth = 70;
+const mapWidth = 65;
 
 export default function Home(): ReactElement {
   const [height, setHeight] = useState<string>('');

--- a/src/screens/MyPromotions.tsx
+++ b/src/screens/MyPromotions.tsx
@@ -1,10 +1,9 @@
+import { Checkbox, Col, Row } from 'antd';
 import React, { CSSProperties, ReactElement } from 'react';
-import { Checkbox, Row, Col } from 'antd';
 
+import UploadPromoButton from '../components/button/UploadPromoButton';
 import DropdownMenu from '../components/DropdownMenu';
 import PromotionCard from '../components/promotion/PromotionCard';
-import UploadPromoButton from '../components/button/UploadPromoButton';
-
 import { Dropdown, DropdownType } from '../types/dropdown';
 import { Promotion, Schedule, User } from '../types/promotion';
 

--- a/src/services/GooglePlacesService.ts
+++ b/src/services/GooglePlacesService.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
 import axios, { AxiosError, AxiosResponse } from 'axios';
 import * as dotenv from 'dotenv';
+
 import { RestaurantDetails } from '.././types/RestaurantDetails';
 import { RestaurantInfo } from '../types/RestaurantInfo';
 

--- a/src/services/PromotionService.ts
+++ b/src/services/PromotionService.ts
@@ -1,4 +1,5 @@
 import { FilterOptions, Promotion, Sort } from '../types/promotion';
+import { Restaurant } from '../types/restaurant';
 import Routes from '../utils/routes';
 
 type PromotionsSuccess = Promotion[];
@@ -43,6 +44,32 @@ export async function getPromotions(query?: Record<string, string>[]): Promise<P
       // Allow caller to handle error
       throw err;
     });
+}
+
+export async function getRestaurant({ id }: Promotion): Promise<Restaurant> {
+  // TODO: find restaurant given placeId from promotion
+  return {
+    id,
+    address: '1850 W 4th Ave, Vancouver, BC V6J 1M3',
+    cuisineType: 'Italian',
+    distance: 500,
+    name: 'Trattoria',
+    phoneNumber: '604-732-1441',
+    photos: [],
+    price: '$$',
+    rating: 4.1,
+    reviews: 'https://google.com',
+    website: 'https://www.glowbalgroup.com/trattoria/trattoria-burnaby.html',
+    hours: {
+      sunday: '10:30 AM - Late',
+      monday: '11:30 AM - Late',
+      tuesday: '11:30 AM - Late',
+      wednesday: '11:30 AM - Late',
+      thursday: '11:30 AM - Late',
+      friday: '11:30 AM - Late',
+      saturday: '10:30 AM - Late',
+    },
+  };
 }
 
 /**

--- a/src/types/restaurant.ts
+++ b/src/types/restaurant.ts
@@ -1,0 +1,24 @@
+export type Restaurant = {
+  id: string;
+  address: string;
+  cuisineType: string;
+  distance: number;
+  hours: Hours;
+  name: string;
+  phoneNumber: string;
+  photos: Array<{ src: string }>;
+  price: string;
+  rating: number;
+  reviews: string;
+  website: string;
+};
+
+type Hours = {
+  sunday: string;
+  monday: string;
+  tuesday: string;
+  wednesday: string;
+  thursday: string;
+  friday: string;
+  saturday: string;
+};

--- a/test/services/GooglePlacesService.test.ts
+++ b/test/services/GooglePlacesService.test.ts
@@ -1,8 +1,9 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import { AxiosError } from 'axios';
+import * as dotenv from 'dotenv';
+
 import { GooglePlacesService } from '../../src/services/GooglePlacesService';
 import { RestaurantDetails } from '../../src/types/RestaurantDetails';
-import * as dotenv from 'dotenv';
 import { RestaurantInfo } from '../../src/types/RestaurantInfo';
 
 describe('Unit tests for GooglePlacesService', function () {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3849,7 +3849,7 @@ data-urls@^1.0.0, data-urls@^1.1.0:
     whatwg-mimetype "^2.2.0"
     whatwg-url "^7.0.0"
 
-date-fns@^2.15.0:
+date-fns@^2.15.0, date-fns@^2.16.1:
   version "2.16.1"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.16.1.tgz#05775792c3f3331da812af253e1a935851d3834b"
   integrity sha512-sAJVKx/FqrLYHAQeN7VpJrPhagZc9R4ImZIWYRFZaaohR3KzmuK88touwsSwSVT8Qcbd4zoDsnGfX4GFB4imyQ==

--- a/yarn.lock
+++ b/yarn.lock
@@ -4500,6 +4500,11 @@ eslint-plugin-react@7.19.0:
     string.prototype.matchall "^4.0.2"
     xregexp "^4.3.0"
 
+eslint-plugin-simple-import-sort@^7.0.0:
+  version "7.0.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-7.0.0.tgz#a1dad262f46d2184a90095a60c66fef74727f0f8"
+  integrity sha512-U3vEDB5zhYPNfxT5TYR7u01dboFZp+HNpnGhkDB2g/2E4wZ/g1Q9Ton8UwCLfRV9yAKyYqDh62oHOamvkFxsvw==
+
 eslint-scope@^4.0.3:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-4.0.3.tgz#ca03833310f6889a3264781aa82e63eb9cfe7848"


### PR DESCRIPTION
## Description

This change implements the basic infrastructure with the opening and closing of a restaurant card. When a promotion is clicked, the restaurant card for that promotion should show up to the left overlaying the map. However, note that the card is currently using mock data and does not get updated with the correct restaurant information. This will be done in a future PR.

## Notes
- A lot of the files that were changed in this PR are actually just because of small ESlint changes

## Photos
<img width="384" alt="Screen Shot 2021-01-30 at 10 43 55 PM" src="https://user-images.githubusercontent.com/44531733/106376736-db217780-634c-11eb-9a37-ebd5aaac4a3a.png">
