### PR TITLE
chore(Promotions): Migrate #85 - Add styling for promotion card

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@types/node": "^14.14.3",
     "@types/react": "^16.9.53",
     "@types/react-dom": "^16.9.8",
+    "date-fns": "^2.16.1",
     "react": "^17.0.0",
     "react-dom": "^17.0.0",
     "react-scripts": "3.4.4",

--- a/src/components/PromotionList.tsx
+++ b/src/components/PromotionList.tsx
@@ -7,6 +7,7 @@ import { Promotion } from '../types/promotion';
 
 const styles: { [identifier: string]: CSSProperties } = {
   container: {
+    backgroundColor: '#FFEDDC',
     padding: 15,
     paddingBottom: 0,
     overflow: 'auto',
@@ -14,7 +15,7 @@ const styles: { [identifier: string]: CSSProperties } = {
 };
 
 export default function PromotionList({
-  dimensions,
+  dimensions: { width, height },
 }: {
   dimensions: { width: string; height: string };
 }): ReactElement {
@@ -23,8 +24,9 @@ export default function PromotionList({
   const { state: promotionListState, dispatch } = usePromotionsList();
 
   const containerStyles = {
-    marginLeft: `calc(100vw - ${dimensions.width})`,
-    ...dimensions,
+    height,
+    width,
+    marginLeft: `calc(100vw - ${width})`,
     ...styles.container,
   };
 

--- a/src/components/promotion/PromotionCard.tsx
+++ b/src/components/promotion/PromotionCard.tsx
@@ -11,11 +11,14 @@ import PromotionImage from '../promotion/PromotionImage';
 const styles: { [identifier: string]: CSSProperties } = {
   body: {
     display: 'inline-flex',
+    padding: 10,
     textAlign: 'left',
     width: '100%',
-    padding: 10,
   },
   card: {
+    borderRadius: 15,
+    borderWidth: 0,
+    boxShadow: '2px 2px 4px 0px #40333333',
     cursor: 'pointer',
     display: 'inline-block',
     marginBottom: 15,

--- a/src/components/promotion/PromotionDetails.css
+++ b/src/components/promotion/PromotionDetails.css
@@ -1,0 +1,10 @@
+/* Promotion text description */
+.promotion-description {
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  display: -webkit-box;
+  margin-bottom: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  word-break: break-all;
+}

--- a/src/components/promotion/PromotionDetails.tsx
+++ b/src/components/promotion/PromotionDetails.tsx
@@ -4,7 +4,7 @@ import { ClockCircleOutlined, HeartOutlined } from '@ant-design/icons';
 import { Col, Row, Typography } from 'antd';
 import React, { CSSProperties, ReactElement } from 'react';
 
-import { Promotion } from '../../types/promotion';
+import { Promotion, Schedule } from '../../types/promotion';
 
 const { Title, Text } = Typography;
 
@@ -53,6 +53,7 @@ export default function PromotionDetails({
   description,
   expirationDate,
   restaurantName,
+  schedules,
 }: Promotion): ReactElement {
   /**
    * Returns display text for age of promotion.
@@ -104,6 +105,30 @@ export default function PromotionDetails({
     }
   };
 
+  const displaySchedules = (schedules: Schedule[]) => {
+    const formatTime = (startTime: string): string => {
+      const [hour, minute] = startTime.split(':');
+
+      const hourNum = parseInt(hour);
+      const minuteNum = parseInt(minute);
+
+      let formattedTime = `${hourNum === 12 ? hourNum : hourNum % 12}`;
+      if (minuteNum !== 0) {
+        formattedTime += `:${minuteNum}`;
+      }
+      formattedTime += hourNum < 12 ? ' AM' : ' PM';
+      return formattedTime;
+    };
+
+    return schedules.map(({ dayOfWeek, startTime, endTime }) => (
+      <Row>
+        <Text style={styles.schedule}>
+          {dayOfWeek}: {formatTime(startTime) + ' - ' + formatTime(endTime)}
+        </Text>
+      </Row>
+    ));
+  };
+
   const Info = () => (
     <>
       <Row style={styles.header}>
@@ -126,16 +151,9 @@ export default function PromotionDetails({
   const Schedule = () => (
     <Row style={styles.scheduleContainer}>
       <Col span={2}>
-        <ClockCircleOutlined style={{ fontSize: '1em', ...styles.schedule }} />
+        <ClockCircleOutlined style={styles.schedule} />
       </Col>
-      <Col span={22}>
-        <Row>
-          <Text style={styles.schedule}>Tuesday: 10 AM - Late</Text>
-        </Row>
-        <Row>
-          <Text style={styles.schedule}>Wednesday: 7 PM - Late</Text>
-        </Row>
-      </Col>
+      <Col span={22}>{displaySchedules(schedules)}</Col>
     </Row>
   );
 

--- a/src/components/promotion/PromotionDetails.tsx
+++ b/src/components/promotion/PromotionDetails.tsx
@@ -1,21 +1,49 @@
-import { HeartOutlined } from '@ant-design/icons';
+import './PromotionDetails.css';
+
+import { ClockCircleOutlined, HeartOutlined } from '@ant-design/icons';
+import { Col, Row, Typography } from 'antd';
 import React, { CSSProperties, ReactElement } from 'react';
 
 import { Promotion } from '../../types/promotion';
 
+const { Title, Text } = Typography;
+
 const styles: { [identifier: string]: CSSProperties } = {
-  descriptionContainer: {
-    padding: 10,
+  detailsContainer: {
+    paddingLeft: 10,
     textAlign: 'left',
     width: '100%',
   },
+  footer: {
+    color: '#8B8888',
+    fontSize: '0.8em',
+  },
   header: {
-    display: 'flex',
-    justifyContent: 'space-between',
+    fontFamily: 'ABeeZee',
+    fontSize: '1em',
+    lineHeight: '1em',
+    paddingBottom: 5,
   },
   heart: {
-    marginTop: 7,
-    textAlign: 'right',
+    fontSize: '1.5em',
+  },
+  promotionName: {
+    fontSize: '1.5em',
+    fontWeight: 'normal',
+    marginBottom: 0,
+  },
+  restaurantName: {
+    fontSize: '0.9em',
+    lineHeight: '0.9em',
+    textDecoration: 'underline',
+  },
+  schedule: {
+    color: '#8B8888',
+    fontSize: '0.9em',
+  },
+  scheduleContainer: {
+    paddingTop: 10,
+    paddingBottom: 10,
   },
 };
 
@@ -25,18 +53,60 @@ export default function PromotionDetails({
   expirationDate,
   restaurantName = 'Restaurant',
 }: Promotion): ReactElement {
+  const Info = () => (
+    <>
+      <Row style={styles.header}>
+        <Col span={22}>
+          <Title style={styles.promotionName}>{name}</Title>
+        </Col>
+        <Col span={2}>
+          <HeartOutlined style={styles.heart} />
+        </Col>
+      </Row>
+      <Row>
+        <Title style={styles.restaurantName}>{restaurantName}</Title>
+      </Row>
+      <Row>
+        <Text className="promotion-description">{description}</Text>
+      </Row>
+    </>
+  );
+
+  const Schedule = () => (
+    <Row style={styles.scheduleContainer}>
+      <Col span={2}>
+        <ClockCircleOutlined style={{ fontSize: '1em', ...styles.schedule }} />
+      </Col>
+      <Col span={22}>
+        <Row>
+          <Text style={styles.schedule}>Tuesday: 10 AM - Late</Text>
+        </Row>
+        <Row>
+          <Text style={styles.schedule}>Wednesday: 7 PM - Late</Text>
+        </Row>
+      </Col>
+    </Row>
+  );
+
+  const Footer = () => (
+    <Row justify="space-between">
+      <Col>
+        <Text style={styles.footer}>Expires</Text>
+        <Text strong style={styles.footer}>
+          {` ${new Date(expirationDate).toDateString()}`}
+        </Text>
+      </Col>
+      <Col>
+        <Text style={styles.footer}>8 days ago</Text>
+      </Col>
+    </Row>
+  );
+
   return (
-    <div style={styles.descriptionContainer}>
-      <div style={styles.header}>
-        <h2>{name}</h2>
-        <HeartOutlined style={styles.heart} />
-      </div>
-      <h3>{restaurantName}</h3>
-      <p>{description}</p>
-      <p>
-        Expires on
-        <strong>{` ${new Date(expirationDate).toDateString()}`}</strong>
-      </p>
-    </div>
+    <Col style={styles.detailsContainer}>
+      <Info />
+      <Schedule />
+      <Footer />
+    </Col>
   );
 }

--- a/src/components/promotion/PromotionDetails.tsx
+++ b/src/components/promotion/PromotionDetails.tsx
@@ -49,10 +49,61 @@ const styles: { [identifier: string]: CSSProperties } = {
 
 export default function PromotionDetails({
   name,
+  dateAdded,
   description,
   expirationDate,
-  restaurantName = 'Restaurant',
+  restaurantName,
 }: Promotion): ReactElement {
+  /**
+   * Returns display text for age of promotion.
+   *
+   * - If dateAdded < 1 day, displays "X hours ago"
+   * - If 1 day <= dateAdded < 1 week, displays "X days ago"
+   * - If 1 week <= dateAdded < 1 month, displays "X weeks ago"
+   * - If 1 month <= dateAdded < 1 year, displays "X months ago"
+   * - If 1 year <= dateAdded, displays "X years ago"
+   */
+  const promotionAge = (dateAdded: string) => {
+    const oneDayInMs = 24 * 60 * 60 * 1000;
+    const msElapsed = new Date().getTime() - new Date(dateAdded).getTime();
+    const daysAgo = msElapsed / oneDayInMs;
+
+    if (daysAgo < 1) {
+      const oneHourInMs = oneDayInMs / 24;
+      const hoursAgo = msElapsed / oneHourInMs;
+      if (hoursAgo === 1) {
+        return '1 hour ago';
+      }
+      return `${hoursAgo.toFixed(0)} hours ago`;
+    } else if (daysAgo < 7) {
+      if (daysAgo === 1) {
+        return '1 day ago';
+      }
+      return `${oneDayInMs.toFixed(0)} days ago`;
+    } else if (daysAgo < 30) {
+      const oneWeekInMs = oneDayInMs * 7;
+      const weeksAgo = msElapsed / oneWeekInMs;
+      if (weeksAgo === 1) {
+        return '1 week ago';
+      }
+      return `${weeksAgo.toFixed(0)} weeks ago`;
+    } else if (daysAgo < 365) {
+      const oneMonthInMs = oneDayInMs * 30;
+      const monthsAgo = msElapsed / oneMonthInMs;
+      if (monthsAgo === 1) {
+        return '1 month ago';
+      }
+      return `${monthsAgo.toFixed(0)} months ago`;
+    } else if (daysAgo >= 365) {
+      const oneYearInMs = oneDayInMs * 365;
+      const yearsAgo = msElapsed / oneYearInMs;
+      if (yearsAgo === 1) {
+        return '1 year ago';
+      }
+      return `${yearsAgo.toFixed(0)} years ago`;
+    }
+  };
+
   const Info = () => (
     <>
       <Row style={styles.header}>
@@ -97,7 +148,7 @@ export default function PromotionDetails({
         </Text>
       </Col>
       <Col>
-        <Text style={styles.footer}>8 days ago</Text>
+        <Text style={styles.footer}>{promotionAge(dateAdded)}</Text>
       </Col>
     </Row>
   );

--- a/src/components/promotion/PromotionDetails.tsx
+++ b/src/components/promotion/PromotionDetails.tsx
@@ -2,6 +2,7 @@ import './PromotionDetails.css';
 
 import { ClockCircleOutlined, HeartOutlined } from '@ant-design/icons';
 import { Col, Row, Typography } from 'antd';
+import { formatDistanceToNow } from 'date-fns';
 import React, { CSSProperties, ReactElement } from 'react';
 
 import { Promotion, Schedule } from '../../types/promotion';
@@ -57,52 +58,9 @@ export default function PromotionDetails({
 }: Promotion): ReactElement {
   /**
    * Returns display text for age of promotion.
-   *
-   * - If dateAdded < 1 day, displays "X hours ago"
-   * - If 1 day <= dateAdded < 1 week, displays "X days ago"
-   * - If 1 week <= dateAdded < 1 month, displays "X weeks ago"
-   * - If 1 month <= dateAdded < 1 year, displays "X months ago"
-   * - If 1 year <= dateAdded, displays "X years ago"
    */
   const promotionAge = (dateAdded: string) => {
-    const oneDayInMs = 24 * 60 * 60 * 1000;
-    const msElapsed = new Date().getTime() - new Date(dateAdded).getTime();
-    const daysAgo = msElapsed / oneDayInMs;
-
-    if (daysAgo < 1) {
-      const oneHourInMs = oneDayInMs / 24;
-      const hoursAgo = msElapsed / oneHourInMs;
-      if (hoursAgo === 1) {
-        return '1 hour ago';
-      }
-      return `${hoursAgo.toFixed(0)} hours ago`;
-    } else if (daysAgo < 7) {
-      if (daysAgo === 1) {
-        return '1 day ago';
-      }
-      return `${oneDayInMs.toFixed(0)} days ago`;
-    } else if (daysAgo < 30) {
-      const oneWeekInMs = oneDayInMs * 7;
-      const weeksAgo = msElapsed / oneWeekInMs;
-      if (weeksAgo === 1) {
-        return '1 week ago';
-      }
-      return `${weeksAgo.toFixed(0)} weeks ago`;
-    } else if (daysAgo < 365) {
-      const oneMonthInMs = oneDayInMs * 30;
-      const monthsAgo = msElapsed / oneMonthInMs;
-      if (monthsAgo === 1) {
-        return '1 month ago';
-      }
-      return `${monthsAgo.toFixed(0)} months ago`;
-    } else if (daysAgo >= 365) {
-      const oneYearInMs = oneDayInMs * 365;
-      const yearsAgo = msElapsed / oneYearInMs;
-      if (yearsAgo === 1) {
-        return '1 year ago';
-      }
-      return `${yearsAgo.toFixed(0)} years ago`;
-    }
+    return formatDistanceToNow(new Date(dateAdded), { addSuffix: true });
   };
 
   const displaySchedules = (schedules: Schedule[]) => {

--- a/src/components/promotion/PromotionImage.tsx
+++ b/src/components/promotion/PromotionImage.tsx
@@ -13,7 +13,7 @@ const styles: { [identifier: string]: CSSProperties } = {
 };
 
 export default function PromotionImage({
-  // TODO: remove default image
+  // TODO: see https://github.com/ubclaunchpad/PromoPal-backend/issues/101
   src = 'https://d1ralsognjng37.cloudfront.net/92a7b4fb-892c-47bb-b5bb-884c89c254a2.jpeg',
 }: PromotionImageProps): ReactElement {
   return (

--- a/src/components/promotion/PromotionImage.tsx
+++ b/src/components/promotion/PromotionImage.tsx
@@ -1,8 +1,22 @@
 import { Skeleton } from 'antd';
-import React, { ReactElement } from 'react';
+import React, { CSSProperties, ReactElement } from 'react';
 
 import { PromotionImage as PromotionImageProps } from '../../types/promotion';
 
-export default function PromotionImage({ src }: PromotionImageProps): ReactElement {
-  return <div>{src?.length ? <img src={src} alt="" /> : <Skeleton.Image />}</div>;
+const styles: { [identifier: string]: CSSProperties } = {
+  image: {
+    borderRadius: 15,
+    minHeight: '100%',
+    objectFit: 'cover',
+    width: 100,
+  },
+};
+
+export default function PromotionImage({
+  // TODO: remove default image
+  src = 'https://d1ralsognjng37.cloudfront.net/92a7b4fb-892c-47bb-b5bb-884c89c254a2.jpeg',
+}: PromotionImageProps): ReactElement {
+  return (
+    <div>{src?.length ? <img style={styles.image} src={src} alt="" /> : <Skeleton.Image />}</div>
+  );
 }

--- a/src/components/restaurant/RestaurantCard.tsx
+++ b/src/components/restaurant/RestaurantCard.tsx
@@ -24,12 +24,14 @@ const styles: { [identifier: string]: CSSProperties } = {
 };
 
 export default function RestaurantCard(restaurant: Restaurant): ReactElement {
+  const containerPadding = '15px';
+
   return (
     <div style={styles.container}>
       <Col
         style={{
           ...styles.card,
-          left: `calc(70% - 15px - ${styles.card.width}px)`,
+          left: `calc(65% - ${containerPadding} - ${styles.card.width}px)`,
         }}
       >
         <Header {...restaurant} />

--- a/src/screens/Home.tsx
+++ b/src/screens/Home.tsx
@@ -11,7 +11,7 @@ import { Dropdown, DropdownType } from '../types/dropdown';
 import { Sort } from '../types/promotion';
 import Routes from '../utils/routes';
 
-const mapWidth = 70;
+const mapWidth = 65;
 
 export default function Home(): ReactElement {
   const [height, setHeight] = useState<string>('');

--- a/yarn.lock
+++ b/yarn.lock
@@ -3849,7 +3849,7 @@ data-urls@^1.0.0, data-urls@^1.1.0:
     whatwg-mimetype "^2.2.0"
     whatwg-url "^7.0.0"
 
-date-fns@^2.15.0:
+date-fns@^2.15.0, date-fns@^2.16.1:
   version "2.16.1"
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-2.16.1.tgz#05775792c3f3331da812af253e1a935851d3834b"
   integrity sha512-sAJVKx/FqrLYHAQeN7VpJrPhagZc9R4ImZIWYRFZaaohR3KzmuK88touwsSwSVT8Qcbd4zoDsnGfX4GFB4imyQ==


### PR DESCRIPTION
## Description

This change just adds styling to the promotion cards to implement the hi-fi designs. Currently, I just hardcoded the image URL and schedule for each promotion so they're all showing up as the same but this should be updated to use the data from the backend.

## Photos
<img width="467" alt="Screen Shot 2021-01-30 at 11 21 27 PM" src="https://user-images.githubusercontent.com/44531733/106377474-183c3880-6352-11eb-9c0f-a7b862ca394f.png">