### PR TITLE
feat(api-loader): Use @googlemaps/js-api-loader to load Google Maps API

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "test": "jest"
   },
   "dependencies": {
+    "@googlemaps/js-api-loader": "^1.11.1",
     "@types/jest": "^26.0.19",
     "@types/mocha": "^8.2.0",
     "@types/node": "^14.14.3",
@@ -28,7 +29,6 @@
     "@ant-design/icons": "^4.2.2",
     "@commitlint/cli": "^11.0.0",
     "@commitlint/config-conventional": "^11.0.0",
-    "@types/google-maps-react": "^2.0.5",
     "@types/googlemaps": "^3.40.3",
     "@types/react-router-dom": "^5.1.6",
     "@typescript-eslint/eslint-plugin": "^4.6.0",
@@ -39,7 +39,6 @@
     "eslint-config-prettier": "^6.15.0",
     "eslint-plugin-prettier": "^3.1.4",
     "eslint-plugin-simple-import-sort": "^7.0.0",
-    "google-maps-react": "^2.0.6",
     "husky": "^4.3.0",
     "lint-staged": "^10.5.0",
     "prettier": "^2.1.2",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,48 @@
-import React, { ReactElement } from 'react';
+import { LoadingOutlined } from '@ant-design/icons';
+import { Spin } from 'antd';
+import React, { CSSProperties, ReactElement, useEffect, useState } from 'react';
 
 import Router from './Router';
+import GoogleMapsApiLoaderService from './services/GoogleMapsApiLoaderService';
+
+const styles: { [identifier: string]: CSSProperties } = {
+  container: {
+    height: '100%',
+    width: '100%',
+  },
+  spinner: {
+    alignItems: 'center',
+    display: 'flex',
+    justifyContent: 'center',
+    height: '100%',
+    width: '100%',
+  },
+  spinnerIcon: {
+    fontSize: '4em',
+  },
+};
 
 function App(): ReactElement {
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+
+  /**
+   * Loads dependencies on initial render.
+   * Displays a spinner for the minimum of either: (a) the duration of the loading period or (b) 2 seconds.
+   */
+  useEffect(() => {
+    const start = Date.now();
+    GoogleMapsApiLoaderService.load().finally(() => {
+      const minWaitTime = 2000;
+      const msWaited = Date.now() - start;
+      setTimeout(() => setIsLoading(false), Math.max(0, minWaitTime - msWaited));
+    });
+  }, []);
+
+  const indicator = <LoadingOutlined style={styles.spinnerIcon} spin />;
+
   return (
-    <div className="App">
-      <Router />
+    <div className="App" style={styles.container}>
+      {isLoading ? <Spin indicator={indicator} style={styles.spinner} /> : <Router />}
     </div>
   );
 }

--- a/src/components/MapContainer.tsx
+++ b/src/components/MapContainer.tsx
@@ -1,5 +1,6 @@
-import { GoogleApiWrapper, Map, Marker } from 'google-maps-react';
-import React, { ReactElement, useEffect, useState } from 'react';
+import React, { ReactElement, useEffect } from 'react';
+
+import GooglePlacesApiLoaderService from '../services/GoogleMapsApiLoaderService';
 
 const locations: google.maps.LatLngLiteral[] = [
   { lat: 49.246213, lng: -123.1691 },
@@ -19,30 +20,22 @@ function mapCenter(locations: google.maps.LatLngLiteral[]) {
 
 function MapContainer({
   dimensions,
-  google,
 }: {
   dimensions: { width: string; height: string };
-  google: typeof globalThis.google;
 }): ReactElement {
-  const [restaurants] = useState<google.maps.LatLngLiteral[]>(locations);
-
+  /**
+   * Loads the map and markers on initial render.
+   */
   useEffect(() => {
-    // Note: the following is not considered best practice, but is a hacky way to access the DOM Element
-    // within the Map component that has the width and height pre-set to 100%
-    const container = document.getElementById('content-container');
-    const target = container?.firstChild?.firstChild as HTMLElement;
-    target.style.removeProperty('height');
-    target.style.removeProperty('width');
+    const options = {
+      center: mapCenter(locations),
+      zoom: 15,
+    };
+    const map = GooglePlacesApiLoaderService.initializeMap(options);
+    locations.map((position) => new google.maps.Marker({ position, map }));
   }, []);
 
-  return (
-    <Map google={google} zoom={15} style={dimensions} initialCenter={mapCenter(locations)}>
-      {restaurants.map((coordinates: google.maps.LatLngLiteral, index: number) => (
-        <Marker key={index} position={coordinates} onClick={() => alert('Click')} />
-      ))}
-    </Map>
-  );
+  return <div id="map-container" style={dimensions}></div>;
 }
 
-const apiKey = process.env.REACT_APP_GOOGLE_MAPS_API_KEY as string;
-export default GoogleApiWrapper({ apiKey })(MapContainer);
+export default MapContainer;

--- a/src/components/PromotionList.tsx
+++ b/src/components/PromotionList.tsx
@@ -26,7 +26,6 @@ export default function PromotionList({
   const containerStyles = {
     height,
     width,
-    marginLeft: `calc(100vw - ${width})`,
     ...styles.container,
   };
 

--- a/src/index.css
+++ b/src/index.css
@@ -12,3 +12,8 @@ body {
 code {
   font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New', monospace;
 }
+
+#root {
+  height: 100%;
+  width: 100%;
+}

--- a/src/services/GoogleMapsApiLoaderService.ts
+++ b/src/services/GoogleMapsApiLoaderService.ts
@@ -1,0 +1,25 @@
+import { Loader } from '@googlemaps/js-api-loader';
+
+class GoogleMapsApiLoaderService {
+  private loader: Loader;
+  private map: google.maps.Map | null = null;
+
+  public constructor() {
+    this.loader = new Loader({
+      apiKey: process.env.REACT_APP_GOOGLE_MAPS_API_KEY || '',
+      version: 'weekly',
+      libraries: ['geometry', 'places'],
+    });
+  }
+
+  public async load(): Promise<void> {
+    return this.loader.load();
+  }
+
+  public initializeMap(options?: google.maps.MapOptions) {
+    const mapContainerEl = document.getElementById('map-container') as HTMLElement;
+    return (this.map = new google.maps.Map(mapContainerEl, options));
+  }
+}
+
+export default new GoogleMapsApiLoaderService();

--- a/yarn.lock
+++ b/yarn.lock
@@ -1348,6 +1348,13 @@
   resolved "https://registry.yarnpkg.com/@ctrl/tinycolor/-/tinycolor-3.1.7.tgz#1585f67629882002a9f8e15a2941c9a4321bf80c"
   integrity sha512-/0C6fjXbCwu22k8mMsKRSAo9zgu61d2p75Or9IuIC0Vu5CWN88t2QHK93LhNnxnqHWf5SFwFU28w9cKfTmnfvg==
 
+"@googlemaps/js-api-loader@^1.11.1":
+  version "1.11.1"
+  resolved "https://registry.yarnpkg.com/@googlemaps/js-api-loader/-/js-api-loader-1.11.1.tgz#b7f02c04d8d8602fb4bd873b03685fccefce1c6f"
+  integrity sha512-2ug4uBu0onRXTAo7Yxkay5N7pdNIz3XpTElMTLdCtEfQDxikbjeR6GS8atVhblX+ubFBNlXvDzz7VtuXv0vMRQ==
+  dependencies:
+    fast-deep-equal "^3.1.3"
+
 "@hapi/address@2.x.x":
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/@hapi/address/-/address-2.1.4.tgz#5d67ed43f3fd41a69d4b9ff7b56e7c0d1d0a81e5"
@@ -1721,13 +1728,6 @@
   dependencies:
     "@types/minimatch" "*"
     "@types/node" "*"
-
-"@types/google-maps-react@^2.0.5":
-  version "2.0.5"
-  resolved "https://registry.yarnpkg.com/@types/google-maps-react/-/google-maps-react-2.0.5.tgz#17cdf20cb6d8ae481f9b2fcfd93dcdaaa14cd069"
-  integrity sha512-qcsYlHiNH169Vf7jmkEwbzBDqBfqqzYkTgK1vL7qkWVZI04wFESADYVITuQunrZ9swY/SG+tTWUIXMlY4W8byw==
-  dependencies:
-    google-maps-react "*"
 
 "@types/googlemaps@^3.40.3":
   version "3.40.3"
@@ -5058,7 +5058,7 @@ extsprintf@^1.2.0:
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.0.tgz#e2689f8f356fad62cca65a3a91c5df5f9551692f"
   integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
 
-fast-deep-equal@^3.1.1:
+fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
   integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
@@ -5631,11 +5631,6 @@ globby@^6.1.0:
     object-assign "^4.0.1"
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
-
-google-maps-react@*, google-maps-react@^2.0.6:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/google-maps-react/-/google-maps-react-2.0.6.tgz#0473356207ab6b47227b393b89e4b83f6eab06da"
-  integrity sha512-M8Eo9WndfQEfxcmm6yRq03qdJgw1x6rQmJ9DN+a+xPQ3K7yNDGkVDbinrf4/8vcox7nELbeopbm4bpefKewWfQ==
 
 graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.2, graceful-fs@^4.2.4:
   version "4.2.4"


### PR DESCRIPTION
Replaced the google-maps-react library with @googlemaps/js-api-loader to load the Google Maps API dynamically instead of via a script: https://developers.google.com/maps/documentation/javascript/overview#Loading_the_Maps_API

This is a pre-requisite for using the other Google services throughout the app, and this allows us to load the Google Maps API when the app starts instead of when the Map container is first loaded.