### PR TITLE
fix: Fix get promotions page and add loading icon

### DIFF
--- a/src/components/PromotionList.tsx
+++ b/src/components/PromotionList.tsx
@@ -1,5 +1,5 @@
 import { Place } from '@googlemaps/google-maps-services-js';
-import { Pagination } from 'antd';
+import { Pagination, Space, Spin } from 'antd';
 import React, {
   CSSProperties,
   ReactElement,
@@ -65,6 +65,11 @@ export default function PromotionList(props: Props): ReactElement {
     height: props.dimensions.height,
     width: props.dimensions.width,
     ...styles.container,
+  };
+
+  const loadingStyle: CSSProperties = {
+    top: '50%',
+    position: 'relative',
   };
 
   /**
@@ -168,11 +173,9 @@ export default function PromotionList(props: Props): ReactElement {
   useEffect(() => {
     if (promotionsState.searchQuery) {
       promotionsDispatch({ type: PromotionsDispatch.DATA_LOADING });
-      PromotionService.getPromotions([
-        {
-          searchQuery: promotionsState.searchQuery,
-        },
-      ]).then((promotions) => {
+      PromotionService.getPromotions({
+        searchQuery: promotionsState.searchQuery,
+      }).then((promotions) => {
         promotionsDispatch({ type: PromotionsDispatch.DATA_SUCCESS });
         setPromotions(promotions);
       });
@@ -181,33 +184,42 @@ export default function PromotionList(props: Props): ReactElement {
 
   return (
     <div style={containerStyles} ref={container}>
-      {promotionsToDisplay.map((promotion) => (
-        <PromotionCard
-          key={promotion.id}
-          id={promotion.id}
-          boldDescription={promotion.boldDescription}
-          boldName={promotion.boldName}
-          dateAdded={promotion.dateAdded}
-          expirationDate={promotion.expirationDate}
-          description={promotion.description}
-          image={promotion.image}
-          isSavedByUser={promotion.isSavedByUser}
-          name={promotion.name}
-          placeId={promotion.restaurant.id}
-          // TODO: https://promopal.atlassian.net/browse/PP-96
-          restaurantName=""
-          schedules={promotion.schedules}
-          onSaveButtonClick={() => onSaveButtonClick(promotion.id)}
-          onCardClick={() => onClickHandler(promotion.restaurant)}
+      {promotionsState.isLoading && !promotionsState.hasError && (
+        <Space style={loadingStyle} size="middle">
+          <Spin size="large" />
+        </Space>
+      )}
+      {!promotionsState.isLoading &&
+        !promotionsState.hasError &&
+        promotionsToDisplay.map((promotion) => (
+          <PromotionCard
+            key={promotion.id}
+            id={promotion.id}
+            boldDescription={promotion.boldDescription}
+            boldName={promotion.boldName}
+            dateAdded={promotion.dateAdded}
+            expirationDate={promotion.expirationDate}
+            description={promotion.description}
+            image={promotion.image}
+            isSavedByUser={promotion.isSavedByUser}
+            name={promotion.name}
+            placeId={promotion.restaurant.id}
+            // TODO: https://promopal.atlassian.net/browse/PP-96
+            restaurantName=""
+            schedules={promotion.schedules}
+            onSaveButtonClick={() => onSaveButtonClick(promotion.id)}
+            onCardClick={() => onClickHandler(promotion.restaurant)}
+          />
+        ))}
+      {!promotionsState.isLoading && !promotionsState.hasError && (
+        <Pagination
+          size="small"
+          defaultCurrent={1}
+          current={props.pageNum}
+          onChange={onPageChange}
+          total={promotions.length}
         />
-      ))}
-      <Pagination
-        size="small"
-        defaultCurrent={1}
-        current={props.pageNum}
-        onChange={onPageChange}
-        total={promotions.length}
-      />
+      )}
     </div>
   );
 }

--- a/src/components/PromotionList.tsx
+++ b/src/components/PromotionList.tsx
@@ -1,5 +1,6 @@
+import { LoadingOutlined } from '@ant-design/icons';
 import { Place } from '@googlemaps/google-maps-services-js';
-import { Pagination, Space, Spin } from 'antd';
+import { Pagination, Spin } from 'antd';
 import React, {
   CSSProperties,
   ReactElement,
@@ -31,6 +32,16 @@ const styles: { [identifier: string]: CSSProperties } = {
     overflow: 'auto',
     scrollBehavior: 'smooth',
     textAlign: 'center',
+  },
+  spinner: {
+    alignItems: 'center',
+    display: 'flex',
+    justifyContent: 'center',
+    height: '100%',
+    width: '100%',
+  },
+  spinnerIcon: {
+    fontSize: '4em',
   },
 };
 
@@ -65,11 +76,6 @@ export default function PromotionList(props: Props): ReactElement {
     height: props.dimensions.height,
     width: props.dimensions.width,
     ...styles.container,
-  };
-
-  const loadingStyle: CSSProperties = {
-    top: '50%',
-    position: 'relative',
   };
 
   /**
@@ -182,12 +188,12 @@ export default function PromotionList(props: Props): ReactElement {
     }
   }, [promotionsDispatch, promotionsState.searchQuery]);
 
+  const indicator = <LoadingOutlined style={styles.spinnerIcon} spin />;
+
   return (
     <div style={containerStyles} ref={container}>
       {promotionsState.isLoading && !promotionsState.hasError && (
-        <Space style={loadingStyle} size="middle">
-          <Spin size="large" />
-        </Space>
+        <Spin indicator={indicator} style={styles.spinner} />
       )}
       {!promotionsState.isLoading &&
         !promotionsState.hasError &&

--- a/src/services/AmazonS3Service.ts
+++ b/src/services/AmazonS3Service.ts
@@ -69,7 +69,7 @@ class AmazonS3Service {
   }
 
   getImageUrl(promotionId: string): string {
-    return `https://promopal.s3-us-west-1.amazonaws.com/${promotionId}`
+    return `https://promopal.s3-us-west-1.amazonaws.com/${promotionId}`;
   }
 }
 

--- a/src/services/PromotionService.ts
+++ b/src/services/PromotionService.ts
@@ -25,21 +25,17 @@ import GooglePlacesService from './GooglePlacesService';
  *
  * @param query [optional] - An array of objects with key-value pairs for the query parameters
  */
-export async function getPromotions(query?: GetPromotionDTO[]): Promise<Promotion[]> {
+export async function getPromotions(query?: GetPromotionDTO): Promise<Promotion[]> {
   const userId = UserService.userId;
-  let endpoint = Routes.PROMOTIONS.GET(userId);
-  if (query && query.length > 0) {
-    endpoint += '?';
-    query.forEach((param: GetPromotionDTO, index: number) => {
-      Object.entries(param).forEach(([key, value], paramIdx) => {
-        // First query param is not prefixed by an ampersand
-        endpoint += `${index + paramIdx > 0 ? '&' : ''}${key}=${value}`;
-      });
-    });
-  }
+  const endpoint = Routes.PROMOTIONS.GET;
 
   return axios
-    .get(endpoint)
+    .get(endpoint, {
+      params: {
+        ...query,
+        userId: UserService.userId,
+      },
+    })
     .then(({ data }: AxiosResponse<GetPromotionsResponse>) => {
       if (isError<GetPromotionsResponse>(data)) {
         return Promise.reject(data);
@@ -99,36 +95,34 @@ export async function getRestaurant(restaurantId: string): Promise<Place> {
 export async function queryPromotions(filters: FilterOptions, sort?: Sort): Promise<Promotion[]> {
   const { cuisine, dayOfWeek, discountType, promotionType } = filters;
 
-  const promotionQueryDTO: Record<string, string>[] = [];
-  if (cuisine?.length > 0) {
-    cuisine.forEach((cuisine: string) => promotionQueryDTO.push({ cuisine }));
-  }
-  if (dayOfWeek.length > 0) {
-    dayOfWeek.forEach((dayOfWeek: string) => promotionQueryDTO.push({ dayOfWeek }));
-  }
+  const promotionQueryDTO: GetPromotionDTO = {
+    cuisine,
+    // note we only support querying one day of week at the moment
+    dayOfWeek: dayOfWeek.length > 0 ? dayOfWeek[0] : undefined,
+    // note we only support querying one promotion type at the moment
+    promotionType: promotionType.length > 0 ? promotionType[0] : undefined,
+  };
+
   if (discountType?.length > 0) {
     // Handle case where filter is one of ["$ Off", "% Off"]
     let discount = 'Other';
     if (discountType !== 'Other') {
       discount = discountType.substring(0, 1);
     }
-    promotionQueryDTO.push({ discountType: discount });
-  }
-  if (promotionType?.length > 0) {
-    promotionType.forEach((promotionType: string) => promotionQueryDTO.push({ promotionType }));
+    promotionQueryDTO.discountType = discount;
   }
 
-  if (sort) {
-    const queryParams: { [paramKey: string]: string } = { sort };
-    if (sort === Sort.Distance) {
-      const {
-        coords: { latitude, longitude },
-      } = await LocationService.GeolocationPosition.getCurrentLocation();
-      queryParams.lat = `${latitude}`;
-      queryParams.lon = `${longitude}`;
-    }
-    promotionQueryDTO.push(queryParams);
-  }
+  // if (sort) {
+  //   const queryParams: { [paramKey: string]: string } = { sort };
+  //   if (sort === Sort.Distance) {
+  //     const {
+  //       coords: { latitude, longitude },
+  //     } = await LocationService.GeolocationPosition.getCurrentLocation();
+  //     queryParams.lat = `${latitude}`;
+  //     queryParams.lon = `${longitude}`;
+  //   }
+  //   promotionQueryDTO.push(queryParams);
+  // }
 
   return getPromotions(promotionQueryDTO);
 }

--- a/src/services/PromotionService.ts
+++ b/src/services/PromotionService.ts
@@ -1,7 +1,6 @@
 import { Place } from '@googlemaps/google-maps-services-js';
 import axios, { AxiosResponse } from 'axios';
 
-import LocationService from '../services/LocationService';
 import UserService from '../services/UserService';
 import {
   DeletePromotionsResponse,
@@ -26,7 +25,6 @@ import GooglePlacesService from './GooglePlacesService';
  * @param query [optional] - An array of objects with key-value pairs for the query parameters
  */
 export async function getPromotions(query?: GetPromotionDTO): Promise<Promotion[]> {
-  const userId = UserService.userId;
   const endpoint = Routes.PROMOTIONS.GET;
 
   return axios

--- a/src/utils/routes.ts
+++ b/src/utils/routes.ts
@@ -7,7 +7,7 @@ export default {
     PROMOTION_TYPES: '/enums/PromotionType',
   },
   PROMOTIONS: {
-    GET: (userId: string): string => `/promotions/?userId=${userId}`,
+    GET: '/promotions',
     DELETE: (promotionId: string): string => `/promotions/${promotionId}`,
     POST: '/promotions',
   },


### PR DESCRIPTION
What's in this PR:
- If we called GET /promotions with the userId, our request would fail if we added any additional query parameters, for e.g. if we add additional filters like cuisine type or day of week. 
   - I think there was something strange going on with how we were constructing the URL
   - I did some refactoring and used axios's ability to specify request params
- Added loading icon when we add filters, use full text search, when refresh page and promotions are loading, etc

![GetPromoSpinner](https://user-images.githubusercontent.com/49849754/113650673-74b71f00-9645-11eb-874e-2c7ecd18c24c.gif)
