### PR TITLE
fix: Make website open in new tab and can search on empty promotions

### DIFF
--- a/src/components/PromotionList.tsx
+++ b/src/components/PromotionList.tsx
@@ -177,15 +177,13 @@ export default function PromotionList(props: Props): ReactElement {
    * When a search query is set, fetches promotions that satisfy the query.
    */
   useEffect(() => {
-    if (promotionsState.searchQuery) {
-      promotionsDispatch({ type: PromotionsDispatch.DATA_LOADING });
-      PromotionService.getPromotions({
-        searchQuery: promotionsState.searchQuery,
-      }).then((promotions) => {
-        promotionsDispatch({ type: PromotionsDispatch.DATA_SUCCESS });
-        setPromotions(promotions);
-      });
-    }
+    promotionsDispatch({ type: PromotionsDispatch.DATA_LOADING });
+    PromotionService.getPromotions({
+      searchQuery: promotionsState.searchQuery ? promotionsState.searchQuery : undefined,
+    }).then((promotions) => {
+      promotionsDispatch({ type: PromotionsDispatch.DATA_SUCCESS });
+      setPromotions(promotions);
+    });
   }, [promotionsDispatch, promotionsState.searchQuery]);
 
   const indicator = <LoadingOutlined style={styles.spinnerIcon} spin />;

--- a/src/components/restaurant/card/Header.tsx
+++ b/src/components/restaurant/card/Header.tsx
@@ -46,7 +46,9 @@ export default function Header(props: Props): ReactElement {
   const Buttons = (): ReactElement => (
     <Row className="action-buttons restaurant-card-header-component">
       <Button className="action-button">
-        <a href={props.website}>Website</a>
+        <a href={props.website} target="_blank">
+          Website
+        </a>
       </Button>
       {/* <Button className="action-button">
         <a href="/">Directions</a>

--- a/src/components/restaurant/card/Header.tsx
+++ b/src/components/restaurant/card/Header.tsx
@@ -46,7 +46,7 @@ export default function Header(props: Props): ReactElement {
   const Buttons = (): ReactElement => (
     <Row className="action-buttons restaurant-card-header-component">
       <Button className="action-button">
-        <a href={props.website} target="_blank">
+        <a href={props.website} target="_blank" rel="noopener noreferrer">
           Website
         </a>
       </Button>


### PR DESCRIPTION
If I enter something in the search bar like "fry", I cannot "undo" my search to see all the promotions again. I thought it would make sense as a user, if I delete everything in my search bar and press enter, then it'll just get me all the promotions again